### PR TITLE
Added a method to delete the first node in a Singly Linked List

### DIFF
--- a/src/List/SinglyLinkedList.java
+++ b/src/List/SinglyLinkedList.java
@@ -1,7 +1,4 @@
 package List;
-
-import javax.swing.*;
-
 public class SinglyLinkedList
 {
     private ListNode head;
@@ -90,6 +87,22 @@ public class SinglyLinkedList
         }
     }
 
+    // Delete first node
+    public ListNode deleteFirst()
+    {
+        if(head == null)
+        {
+            return null;
+        }
+        else
+        {
+            ListNode temp = head;
+            head = head.next;
+            temp.next = null;
+            return temp;
+        }
+    }
+
     public static void main(String[] args)
     {
         SinglyLinkedList sll = new SinglyLinkedList();
@@ -131,6 +144,10 @@ public class SinglyLinkedList
         System.out.println("-----------------------------------------");
         sll.addAtGivenPosition(9,87);
         System.out.println("SLL after adding a new element at position 9");
+        sll.display();
+        System.out.println("-----------------------------------------");
+        sll.deleteFirst();
+        System.out.println("SLL after deleting first node");
         sll.display();
         System.out.println("-----------------------------------------");
     }


### PR DESCRIPTION
- Implemented the `deleteFirst `method to remove the first node from a Singly Linked List.
- The method checks if the list is empty by verifying if the `head `is `null`. If the list is empty, it returns `null`.
- If the list contains nodes, it temporarily stores the `head `node in a variable `temp`, updates the `head `to point to the next node, and disconnects the original first node from the list by setting `temp.next` to `null`.
- The method then returns the deleted node, allowing for its value or further operations if needed.
- This method provides an efficient way to remove the first element in the linked list, supporting common list operations.