### PR TITLE
Added a method to delete the last node in a Singly Linked List

### DIFF
--- a/src/List/SinglyLinkedList.java
+++ b/src/List/SinglyLinkedList.java
@@ -103,6 +103,25 @@ public class SinglyLinkedList
         }
     }
 
+    // Delete last node
+    public ListNode deleteLast()
+    {
+        if(head == null || head.next == null)
+        {
+            return head;
+        }
+            ListNode current = head;
+            ListNode previous = null;
+            while(current.next != null)
+            {
+                previous = current;
+                current = current.next;
+            }
+            previous.next = null;
+            return current;
+
+    }
+
     public static void main(String[] args)
     {
         SinglyLinkedList sll = new SinglyLinkedList();
@@ -128,7 +147,6 @@ public class SinglyLinkedList
         sll.display();
         System.out.println("Length of new SLL: " + sll.findLength());
         System.out.println("-----------------------------------------");
-
         sll.addLast(36);
         System.out.println("SLL after adding a new element at last");
         sll.display();
@@ -148,6 +166,10 @@ public class SinglyLinkedList
         System.out.println("-----------------------------------------");
         sll.deleteFirst();
         System.out.println("SLL after deleting first node");
+        sll.display();
+        System.out.println("-----------------------------------------");
+        sll.deleteLast();
+        System.out.println("SLL after deleting last node");
         sll.display();
         System.out.println("-----------------------------------------");
     }


### PR DESCRIPTION
- Implemented the `deleteLast `method to remove the last node from a Singly Linked List.
- The method checks two conditions: if the list is empty `(head == null)` or if the list contains only one node `(head.next == null)`. In either case, it returns the `head `node, as it is the only node to be removed.
- If the list contains multiple nodes, the method iterates through the list to find the last node. It maintains two pointers: `current `(to traverse the list) and `previous `(to track the node just before the last node).
- Once the last node is identified, the `previous.next` is set to `null`, effectively removing the last node from the list.
- The method then returns the deleted node, allowing further operations on it if necessary.
- This method efficiently handles the removal of the last element, a common operation in linked lists.