### PR TITLE
Added a method to delete a node at a given position in a Singly Linked List.

### DIFF
--- a/src/List/SinglyLinkedList.java
+++ b/src/List/SinglyLinkedList.java
@@ -122,6 +122,27 @@ public class SinglyLinkedList
 
     }
 
+    // Delete node at given position
+    public void deleteAtGivenPosition(int position)
+    {
+        if(position == 1)
+        {
+            head = head.next;
+        }
+        else
+        {
+            ListNode previous = head;
+            int count = 1;
+            while(count < position-1)
+            {
+                previous = previous.next;
+                count++;
+            }
+            ListNode current = previous.next;
+            previous.next = current.next;
+        }
+    }
+
     public static void main(String[] args)
     {
         SinglyLinkedList sll = new SinglyLinkedList();
@@ -170,6 +191,12 @@ public class SinglyLinkedList
         System.out.println("-----------------------------------------");
         sll.deleteLast();
         System.out.println("SLL after deleting last node");
+        sll.display();
+        System.out.println("-----------------------------------------");
+        sll.deleteAtGivenPosition(3);
+        sll.deleteAtGivenPosition(3);
+        sll.deleteAtGivenPosition(3);
+        System.out.println("SLL after adding a new element at position 3");
         sll.display();
         System.out.println("-----------------------------------------");
     }


### PR DESCRIPTION
- Implemented the `deleteAtGivenPosition `method to remove a node from a specific position in a Singly Linked List.
- If the position is `1`, the head of the list is updated to point to the second node, effectively removing the first node.
- For positions greater than `1`, the method iterates through the list to find the node at the desired position.
- Two pointers are used: `previous `to track the node just before the target position and `current `to identify the node to be deleted.
- The `previous.next` is updated to skip the current node and point to the node after it, effectively removing the node at the given position.
- This method efficiently handles the deletion of nodes at any position, ensuring the integrity of the list structure.