### PR TITLE
Added a method to find the nth node from the end of a Singly Linked List

### DIFF
--- a/src/List/SinglyLinkedList.java
+++ b/src/List/SinglyLinkedList.java
@@ -194,6 +194,38 @@ public class SinglyLinkedList
         return slowPtr;
     }
 
+    // Find nth node from the end
+    public ListNode findNthNodeFromEnd(int n)
+    {
+        if(head == null)
+        {
+            return  null;
+        }
+        if(n <= 0)
+        {
+            throw new IllegalArgumentException("Invalid value: n = " + n);
+        }
+        ListNode refPtr = head;
+        ListNode mainPtr = head;
+        int count = 0;
+        while(count < n)
+        {
+            if(refPtr == null)
+            {
+                throw new IllegalArgumentException(n + " is greater than the number of nodes in the list");
+            }
+            refPtr = refPtr.next;
+            count++;
+        }
+        while(refPtr != null)
+        {
+            refPtr = refPtr.next;
+            mainPtr = mainPtr.next;
+        }
+        return  mainPtr;
+
+    }
+
     public static void main(String[] args)
     {
         SinglyLinkedList sll = new SinglyLinkedList();
@@ -263,6 +295,10 @@ public class SinglyLinkedList
         System.out.println("-----------------------------------------");
         sll.display();
         System.out.println("Middle Node: "+(sll.findMiddle().data));
+        System.out.println("-----------------------------------------");
+        int nthNodeFromEnd = 3;
+        sll.display();
+        System.out.println(nthNodeFromEnd + " node from the end is : " +sll.findNthNodeFromEnd(nthNodeFromEnd).data);
         System.out.println("-----------------------------------------");
     }
 }


### PR DESCRIPTION
- Implemented the `findNthNodeFromEnd `method to retrieve the nth node from the end of a Singly Linked List.
- Utilized two pointers: `refPtr `and `mainPtr`.
- The `refPtr `is first advanced n nodes ahead in the list.
- Afterward, both `refPtr `and `mainPtr `are moved one node at a time.
- When `refPtr `reaches the end of the list, `mainPtr `will point to the nth node from the end.
- This method efficiently finds the desired node in a single pass (**O(n)** time complexity) with constant space.
- Handles edge cases where `n `is less than or equal to zero, or greater than the number of nodes, by throwing an `IllegalArgumentException `for invalid input values.